### PR TITLE
Optimize GetMatchingArchetypes method performance

### DIFF
--- a/EasyEcs.Core/Context.Archetypes.cs
+++ b/EasyEcs.Core/Context.Archetypes.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using EasyEcs.Core.Components;
@@ -10,7 +11,8 @@ public partial class Context
     internal readonly Dictionary<Tag, Archetype> Archetypes = new();
 
     // Query cache: QueryTag -> List of matching archetypes (O(1) lookup after first query)
-    private readonly Dictionary<Tag, List<Archetype>> _queryCache = new();
+    // Using ConcurrentDictionary for lock-free reads on cache hits
+    private readonly ConcurrentDictionary<Tag, List<Archetype>> _queryCache = new();
 
     // Lock for structural modifications (simple object lock for .NET 8.0 compatibility)
     private readonly object _structuralLock = new();
@@ -50,16 +52,23 @@ public partial class Context
 
     /// <summary>
     /// Get all archetypes matching the query tag.
-    /// Uses O(1) cached lookup after first access.
-    /// Thread-safe: always locks to prevent race conditions with cache invalidation.
+    /// Uses O(1) cached lookup after first access with lock-free fast path.
+    /// Thread-safe: uses double-checked locking for cache misses only.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
     internal List<Archetype> GetMatchingArchetypes(in Tag queryTag)
     {
+        // Fast path: lock-free cache lookup (common case for GroupOf operations)
+        // ConcurrentDictionary.TryGetValue is thread-safe and doesn't require locking
+        if (_queryCache.TryGetValue(queryTag, out var cached))
+            return cached;
+
+        // Slow path: cache miss, need to build and cache the result
+        // Use lock to ensure only one thread builds the cache entry and to safely read Archetypes
         lock (_structuralLock)
         {
-            // Check cache
-            if (_queryCache.TryGetValue(queryTag, out var cached))
+            // Double-check after acquiring lock (another thread might have built it)
+            if (_queryCache.TryGetValue(queryTag, out cached))
                 return cached;
 
             // Build list of matching archetypes
@@ -77,7 +86,7 @@ public partial class Context
                 }
             }
 
-            // Cache for future queries
+            // Cache for future queries (ConcurrentDictionary handles concurrent access)
             _queryCache[queryTag] = matching;
             return matching;
         }


### PR DESCRIPTION
Previously, GetMatchingArchetypes acquired a lock for every call, including cache hits. This was wasteful for high-frequency GroupOf operations where the query cache is already populated.

Changes:
- Use ConcurrentDictionary for _queryCache to enable thread-safe lock-free reads
- Implement double-checked locking pattern:
  * Fast path: Check cache without lock (common case)
  * Slow path: Lock only on cache miss to build/cache results
- Maintain thread safety for structural modifications in GetOrCreateArchetype

Performance impact:
- Cache hits are now lock-free, eliminating monitor overhead
- Reduces CPU cycles wasted on GroupOf operations
- Maintains full thread safety with minimal code changes

The optimization is especially beneficial for frequently-used queries where archetypes are stable and cache hits dominate.